### PR TITLE
Improve combat engagement

### DIFF
--- a/src/CodefestBot/src/StepHandler_HunterTrapper.java
+++ b/src/CodefestBot/src/StepHandler_HunterTrapper.java
@@ -57,8 +57,8 @@ public class StepHandler_HunterTrapper {
             }
         }
 
-        if (BaseBotLogic.avoidEnemies(hero, gameMap, me)) return;
         if (BaseBotLogic.shootNearby(hero, gameMap, me, inv)) return;
+        if (BaseBotLogic.avoidEnemies(hero, gameMap, me)) return;
         if (BaseBotLogic.breakChestIfNearby(hero, gameMap, me)) return;
         BaseBotLogic.dodgeBulletIfTargeted(hero, gameMap, me);
 

--- a/src/CodefestBot/src/StepHandler_SmartAggressive.java
+++ b/src/CodefestBot/src/StepHandler_SmartAggressive.java
@@ -6,12 +6,19 @@ import jsclub.codefest.sdk.model.GameMap;
 import jsclub.codefest.sdk.model.Inventory;
 import jsclub.codefest.sdk.model.healing_items.HealingItem;
 import jsclub.codefest.sdk.model.weapon.Weapon;
-import jsclub.codefest.sdk.model.npcs.Enemy;
-import jsclub.codefest.sdk.model.obstacles.Obstacle;
 import jsclub.codefest.sdk.model.players.Player;
 
-import java.io.IOException;
+// Reuse shared helper methods
 import java.util.*;
+import java.io.IOException;
+
+// Shared behaviours
+import static java.util.Comparator.comparingDouble;
+
+/**
+ * Aggressive strategy that still prioritizes staying alive.
+ * Uses common helpers from {@link BaseBotLogic} to reduce duplication.
+ */
 
 public class StepHandler_SmartAggressive {
 
@@ -28,25 +35,27 @@ public class StepHandler_SmartAggressive {
         boolean hasGun = inv.getGun() != null;
         boolean isHealthy = player.getHealth() >= MIN_ATTACK_HP;
 
-        List<Node> avoid = getAvoidNodes(gameMap, !hasGun || !isHealthy);
+        List<Node> avoid = BaseBotLogic.buildAvoidList(gameMap, !hasGun || !isHealthy);
 
         // --- ƯU TIÊN LOOT ---
         if (!hasGun) {
-            Weapon gun = getClosest(gameMap.getAllGun(), me);
-            if (gun != null && goTo(hero, gameMap, me, gun, avoid)) return;
+            Weapon gun = BaseBotLogic.getClosest(gameMap.getAllGun(), me);
+            if (gun != null && BaseBotLogic.goTo(hero, gameMap, me, gun, avoid)) return;
         }
 
-        HealingItem heal = getClosest(gameMap.getListHealingItems(), me);
-        if (player.getHealth() < 50 && heal != null && goTo(hero, gameMap, me, heal, avoid)) return;
+        HealingItem heal = BaseBotLogic.getClosest(gameMap.getListHealingItems(), me);
+        if (player.getHealth() < 50 && heal != null && BaseBotLogic.goTo(hero, gameMap, me, heal, avoid)) return;
 
         // --- ENGAGE KHI CÓ LỢI ---
         if (hasGun && isHealthy) {
             Player target = getWeakPlayer(gameMap.getOtherPlayerInfo(), me, inv.getGun().getRange());
             if (target != null) {
-                hero.shoot(getDirection(me, target));
+                hero.shoot(BaseBotLogic.getDirection(me, target));
                 return;
             }
         }
+
+        if (hasGun && BaseBotLogic.shootNearby(hero, gameMap, me, inv)) return;
 
         // --- TRÁNH VÙNG TỐI ---
         if (!PathUtils.checkInsideSafeArea(me, gameMap.getSafeZone(), gameMap.getMapSize())) {
@@ -68,87 +77,21 @@ public class StepHandler_SmartAggressive {
             }
         }
 
+        // --- DODGE VÀ MỞ RƯƠNG ---
+        if (BaseBotLogic.breakChestIfNearby(hero, gameMap, me)) return;
+        if (BaseBotLogic.dodgeBulletIfTargeted(hero, gameMap, me)) return;
+
         // --- RANDOM SAFE MOVE ---
-        moveRandom(hero, gameMap, me, avoid);
+        BaseBotLogic.moveRandom(hero, gameMap, me, avoid);
     }
 
-    private static List<Node> getAvoidNodes(GameMap map, boolean avoidEnemies) {
-        List<Node> avoid = new ArrayList<>(map.getListIndestructibles());
-        avoid.removeAll(map.getObstaclesByTag("CAN_GO_THROUGH"));
-        if (avoidEnemies) {
-            for (Enemy e : map.getListEnemies()) {
-                for (int dx = -1; dx <= 1; dx++) {
-                    for (int dy = -1; dy <= 1; dy++) {
-                        avoid.add(new Node(e.getX() + dx, e.getY() + dy));
-                    }
-                }
-            }
-        }
-        avoid.addAll(map.getOtherPlayerInfo());
-        return avoid;
-    }
-
-    private static <T extends Node> T getClosest(List<T> list, Node from) {
-        return list.stream()
-                .min(Comparator.comparingDouble(n -> PathUtils.distance(from, n)))
-                .orElse(null);
-    }
-
+    // Find a weak target within range
     private static Player getWeakPlayer(List<Player> players, Node from, int range) {
         return players.stream()
                 .filter(p -> p.getHealth() != null && p.getHealth() < 50)
                 .filter(p -> PathUtils.distance(from, p) <= range)
-                .min(Comparator.comparingDouble(p -> PathUtils.distance(from, p)))
+                .min(comparingDouble(p -> PathUtils.distance(from, p)))
                 .orElse(null);
     }
 
-    private static boolean goTo(Hero hero, GameMap map, Node from, Node to, List<Node> avoid) throws IOException {
-        if (from.x == to.x && from.y == to.y) {
-            hero.pickupItem();
-            return true;
-        }
-        String path = PathUtils.getShortestPath(map, avoid, from, to, false);
-        if (path != null && !path.isEmpty()) {
-            hero.move(String.valueOf(path.charAt(0)));
-            return true;
-        }
-        return false;
-    }
-
-    private static void moveRandom(Hero hero, GameMap map, Node current, List<Node> avoid) throws IOException {
-        String[] dirs = {"l", "r", "u", "d"};
-        Collections.shuffle(Arrays.asList(dirs));
-        for (String d : dirs) {
-            Node next = getNext(current, d.charAt(0));
-            if (!isBlocked(next, map, avoid)) {
-                hero.move(d);
-                return;
-            }
-        }
-    }
-
-    private static Node getNext(Node cur, char d) {
-        int x = cur.x, y = cur.y;
-        if (d == 'l') x--;
-        if (d == 'r') x++;
-        if (d == 'u') y--;
-        if (d == 'd') y++;
-        return new Node(x, y);
-    }
-
-    private static boolean isBlocked(Node n, GameMap map, List<Node> avoid) {
-        if (n.x < 0 || n.y < 0 || n.x >= map.getMapSize() || n.y >= map.getMapSize()) return true;
-        for (Node b : avoid) {
-            if (b.x == n.x && b.y == n.y) return true;
-        }
-        return false;
-    }
-
-    private static String getDirection(Node from, Node to) {
-        if (to.x < from.x) return "l";
-        if (to.x > from.x) return "r";
-        if (to.y < from.y) return "u";
-        if (to.y > from.y) return "d";
-        return "";
-    }
 }

--- a/src/CodefestBot/src/StepHandler_StealthOpportunist.java
+++ b/src/CodefestBot/src/StepHandler_StealthOpportunist.java
@@ -6,12 +6,12 @@ import jsclub.codefest.sdk.model.GameMap;
 import jsclub.codefest.sdk.model.Inventory;
 import jsclub.codefest.sdk.model.healing_items.HealingItem;
 import jsclub.codefest.sdk.model.weapon.Weapon;
-import jsclub.codefest.sdk.model.npcs.Enemy;
-import jsclub.codefest.sdk.model.obstacles.Obstacle;
 import jsclub.codefest.sdk.model.players.Player;
 
 import java.io.IOException;
 import java.util.*;
+
+import static java.util.Comparator.comparingDouble;
 
 public class StepHandler_StealthOpportunist {
 
@@ -25,18 +25,18 @@ public class StepHandler_StealthOpportunist {
         Node me = new Node(player.getX(), player.getY());
         Inventory inv = hero.getInventory();
 
-        List<Node> avoid = getAvoidNodes(gameMap, true);
+        List<Node> avoid = BaseBotLogic.buildAvoidList(gameMap, true);
 
         // 1. Nếu chưa có súng, ưu tiên loot
         if (inv.getGun() == null) {
-            Weapon gun = getClosest(gameMap.getAllGun(), me);
-            if (gun != null && goTo(hero, gameMap, me, gun, avoid)) return;
+            Weapon gun = BaseBotLogic.getClosest(gameMap.getAllGun(), me);
+            if (gun != null && BaseBotLogic.goTo(hero, gameMap, me, gun, avoid)) return;
         }
 
         // 2. Nếu máu yếu < 50, tìm hồi máu
         if (player.getHealth() < 50) {
-            HealingItem heal = getClosest(gameMap.getListHealingItems(), me);
-            if (heal != null && goTo(hero, gameMap, me, heal, avoid)) return;
+            HealingItem heal = BaseBotLogic.getClosest(gameMap.getListHealingItems(), me);
+            if (heal != null && BaseBotLogic.goTo(hero, gameMap, me, heal, avoid)) return;
         }
 
         // 3. Late game (game > 7 phút), chủ động săn player yếu
@@ -44,10 +44,11 @@ public class StepHandler_StealthOpportunist {
         if (mapTime >= LATE_GAME_TIME && inv.getGun() != null && player.getHealth() >= MIN_ATTACK_HP) {
             Player target = getWeakPlayer(gameMap.getOtherPlayerInfo(), me, inv.getGun().getRange());
             if (target != null) {
-                hero.shoot(getDirection(me, target));
+                hero.shoot(BaseBotLogic.getDirection(me, target));
                 return;
             }
         }
+        if (inv.getGun() != null && BaseBotLogic.shootNearby(hero, gameMap, me, inv)) return;
 
         // 4. Luôn đảm bảo ở trong bo
         if (!PathUtils.checkInsideSafeArea(me, gameMap.getSafeZone(), gameMap.getMapSize())) {
@@ -60,90 +61,21 @@ public class StepHandler_StealthOpportunist {
         }
 
         // 5. Di chuyển nhẹ vào vùng sáng hoặc gần loot
-        Weapon w = getClosest(gameMap.getAllGun(), me);
-        if (w != null && PathUtils.distance(me, w) < 5 && goTo(hero, gameMap, me, w, avoid)) return;
+        Weapon w = BaseBotLogic.getClosest(gameMap.getAllGun(), me);
+        if (w != null && PathUtils.distance(me, w) < 5 && BaseBotLogic.goTo(hero, gameMap, me, w, avoid)) return;
 
         // 6. Random tránh enemy
-        moveSafe(hero, gameMap, me, avoid);
-    }
+        if (BaseBotLogic.breakChestIfNearby(hero, gameMap, me)) return;
+        if (BaseBotLogic.dodgeBulletIfTargeted(hero, gameMap, me)) return;
 
-    private static List<Node> getAvoidNodes(GameMap map, boolean avoidEnemies) {
-        List<Node> avoid = new ArrayList<>(map.getListIndestructibles());
-        avoid.removeAll(map.getObstaclesByTag("CAN_GO_THROUGH"));
-        if (avoidEnemies) {
-            for (Enemy e : map.getListEnemies()) {
-                for (int dx = -1; dx <= 1; dx++) {
-                    for (int dy = -1; dy <= 1; dy++) {
-                        avoid.add(new Node(e.getX() + dx, e.getY() + dy));
-                    }
-                }
-            }
-        }
-        avoid.addAll(map.getOtherPlayerInfo());
-        return avoid;
-    }
-
-    private static <T extends Node> T getClosest(List<T> list, Node from) {
-        return list.stream()
-                .min(Comparator.comparingDouble(n -> PathUtils.distance(from, n)))
-                .orElse(null);
+        BaseBotLogic.moveRandom(hero, gameMap, me, avoid);
     }
 
     private static Player getWeakPlayer(List<Player> players, Node from, int range) {
         return players.stream()
                 .filter(p -> p.getHealth() != null && p.getHealth() < 40)
                 .filter(p -> PathUtils.distance(from, p) <= range)
-                .min(Comparator.comparingDouble(p -> PathUtils.distance(from, p)))
+                .min(comparingDouble(p -> PathUtils.distance(from, p)))
                 .orElse(null);
-    }
-
-    private static boolean goTo(Hero hero, GameMap map, Node from, Node to, List<Node> avoid) throws IOException {
-        if (from.x == to.x && from.y == to.y) {
-            hero.pickupItem();
-            return true;
-        }
-        String path = PathUtils.getShortestPath(map, avoid, from, to, false);
-        if (path != null && !path.isEmpty()) {
-            hero.move(String.valueOf(path.charAt(0)));
-            return true;
-        }
-        return false;
-    }
-
-    private static void moveSafe(Hero hero, GameMap map, Node current, List<Node> avoid) throws IOException {
-        String[] dirs = {"l", "r", "u", "d"};
-        Collections.shuffle(Arrays.asList(dirs));
-        for (String d : dirs) {
-            Node next = getNext(current, d.charAt(0));
-            if (!isBlocked(next, map, avoid)) {
-                hero.move(d);
-                return;
-            }
-        }
-    }
-
-    private static Node getNext(Node cur, char d) {
-        int x = cur.x, y = cur.y;
-        if (d == 'l') x--;
-        if (d == 'r') x++;
-        if (d == 'u') y--;
-        if (d == 'd') y++;
-        return new Node(x, y);
-    }
-
-    private static boolean isBlocked(Node n, GameMap map, List<Node> avoid) {
-        if (n.x < 0 || n.y < 0 || n.x >= map.getMapSize() || n.y >= map.getMapSize()) return true;
-        for (Node b : avoid) {
-            if (b.x == n.x && b.y == n.y) return true;
-        }
-        return false;
-    }
-
-    private static String getDirection(Node from, Node to) {
-        if (to.x < from.x) return "l";
-        if (to.x > from.x) return "r";
-        if (to.y < from.y) return "u";
-        if (to.y > from.y) return "d";
-        return "";
     }
 }

--- a/src/CodefestBot/src/StepHandler_ZoneDominator.java
+++ b/src/CodefestBot/src/StepHandler_ZoneDominator.java
@@ -6,12 +6,12 @@ import jsclub.codefest.sdk.model.GameMap;
 import jsclub.codefest.sdk.model.Inventory;
 import jsclub.codefest.sdk.model.healing_items.HealingItem;
 import jsclub.codefest.sdk.model.weapon.Weapon;
-import jsclub.codefest.sdk.model.npcs.Enemy;
-import jsclub.codefest.sdk.model.obstacles.Obstacle;
 import jsclub.codefest.sdk.model.players.Player;
 
 import java.io.IOException;
 import java.util.*;
+
+import static java.util.Comparator.comparingDouble;
 
 public class StepHandler_ZoneDominator {
 
@@ -25,18 +25,18 @@ public class StepHandler_ZoneDominator {
 
         Node me = new Node(player.getX(), player.getY());
         Inventory inv = hero.getInventory();
-        List<Node> avoid = getAvoidNodes(gameMap, player.getHealth() < SAFE_HP);
+        List<Node> avoid = BaseBotLogic.buildAvoidList(gameMap, player.getHealth() < SAFE_HP);
 
         // 1. Nếu chưa có súng → loot
         if (inv.getGun() == null) {
-            Weapon gun = getClosest(gameMap.getAllGun(), me);
-            if (gun != null && goTo(hero, gameMap, me, gun, avoid)) return;
+            Weapon gun = BaseBotLogic.getClosest(gameMap.getAllGun(), me);
+            if (gun != null && BaseBotLogic.goTo(hero, gameMap, me, gun, avoid)) return;
         }
 
         // 2. Nếu máu thấp → tìm hồi máu
         if (player.getHealth() < SAFE_HP) {
-            HealingItem heal = getClosest(gameMap.getListHealingItems(), me);
-            if (heal != null && goTo(hero, gameMap, me, heal, avoid)) return;
+            HealingItem heal = BaseBotLogic.getClosest(gameMap.getListHealingItems(), me);
+            if (heal != null && BaseBotLogic.goTo(hero, gameMap, me, heal, avoid)) return;
         }
 
         // 3. Nếu có thính gần rơi, đoán vị trí và đến chiếm
@@ -54,9 +54,10 @@ public class StepHandler_ZoneDominator {
         if (inv.getGun() != null) {
             Player intruder = getTargetInCenter(gameMap.getOtherPlayerInfo(), center, inv.getGun().getRange());
             if (intruder != null) {
-                hero.shoot(getDirection(me, intruder));
+                hero.shoot(BaseBotLogic.getDirection(me, intruder));
                 return;
             }
+            if (BaseBotLogic.shootNearby(hero, gameMap, me, inv)) return;
         }
 
         // 5. Luôn trong bo
@@ -69,29 +70,8 @@ public class StepHandler_ZoneDominator {
         }
 
         // 6. Nếu đang ở trung tâm rồi → đứng canh
-        // Không cần di chuyển thêm
-    }
-
-    private static List<Node> getAvoidNodes(GameMap map, boolean avoidEnemies) {
-        List<Node> avoid = new ArrayList<>(map.getListIndestructibles());
-        avoid.removeAll(map.getObstaclesByTag("CAN_GO_THROUGH"));
-        if (avoidEnemies) {
-            for (Enemy e : map.getListEnemies()) {
-                for (int dx = -1; dx <= 1; dx++) {
-                    for (int dy = -1; dy <= 1; dy++) {
-                        avoid.add(new Node(e.getX() + dx, e.getY() + dy));
-                    }
-                }
-            }
-        }
-        avoid.addAll(map.getOtherPlayerInfo());
-        return avoid;
-    }
-
-    private static <T extends Node> T getClosest(List<T> list, Node from) {
-        return list.stream()
-                .min(Comparator.comparingDouble(n -> PathUtils.distance(from, n)))
-                .orElse(null);
+        if (BaseBotLogic.breakChestIfNearby(hero, gameMap, me)) return;
+        if (BaseBotLogic.dodgeBulletIfTargeted(hero, gameMap, me)) return;
     }
 
     private static Player getTargetInCenter(List<Player> players, Node center, int range) {
@@ -101,26 +81,5 @@ public class StepHandler_ZoneDominator {
                 .filter(p -> PathUtils.distance(center, p) <= range)
                 .findFirst()
                 .orElse(null);
-    }
-
-    private static boolean goTo(Hero hero, GameMap map, Node from, Node to, List<Node> avoid) throws IOException {
-        if (from.x == to.x && from.y == to.y) {
-            hero.pickupItem();
-            return true;
-        }
-        String path = PathUtils.getShortestPath(map, avoid, from, to, false);
-        if (path != null && !path.isEmpty()) {
-            hero.move(String.valueOf(path.charAt(0)));
-            return true;
-        }
-        return false;
-    }
-
-    private static String getDirection(Node from, Node to) {
-        if (to.x < from.x) return "l";
-        if (to.x > from.x) return "r";
-        if (to.y < from.y) return "u";
-        if (to.y > from.y) return "d";
-        return "";
     }
 }


### PR DESCRIPTION
## Summary
- tweak bot behavior so armed heroes fire at enemies
- reorder HunterTrapper priorities to shoot before evading
- allow other strategies to use BaseBotLogic.shootNearby

## Testing
- `javac -cp sdk/CodeFest.jar -d /tmp/classes $(find src/CodefestBot/src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_686604588c588328b1b9492f8ff96daa